### PR TITLE
Fix: 404 error on page refresh using Vercel rewrite configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrites": [
+        {
+            "source": "/(.*)",
+            "destination": "/index.html"
+        }
+    ]
+}


### PR DESCRIPTION
### 🛠️ What This PR Does

This PR fixes the `404 NOT_FOUND` issue that occurs when refreshing client-side routes on the Vercel deployment.

---

### ✨ Changes Made

- Added `vercel.json` in the project root
- Configured a rewrite rule to redirect all routes to `index.html`

---

### 🧠 Why This Is Needed

Vercel resolves refreshed routes as static file paths.  
For SPA-based applications, all routes must be served from `index.html` so the frontend router can handle navigation.

---

### 🧪 How to Test

1. Deploy the app on Vercel
2. Open any client-side route (e.g. `/login`)
3. Refresh the page
4. ✅ Page loads correctly without a 404 error

---

### 🔗 Related Issue

Fixes #1 
